### PR TITLE
Fix Docker running user to root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,5 @@ RUN go install -v
 FROM alpine
 RUN apk update && apk add --no-cache ca-certificates
 EXPOSE 3000
-USER daemon
 COPY --from=builder /go/bin/slack-docker /
 CMD ["/slack-docker"]


### PR DESCRIPTION
This will fix the issue that docker command shows the error:

```
% docker run --rm -e webhook=... -v /var/run/docker.sock:/var/run/docker.sock slack-docker
2018/10/25 00:37:47 Error: Could not get version from the Docker server: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get http://%2Fvar%2Frun%2Fdocker.sock/v1.25/version: dial unix /var/run/docker.sock: connect: permission denied
```