### PR TITLE
Add build for linux arm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION ?= latest
 GITHUB_USERNAME := int128
 GITHUB_REPONAME := slack-docker
 LDFLAGS := -X main.version=$(VERSION)
-OSARCH := linux_arm64 linux_amd64 darwin_amd64 windows_amd64
+OSARCH := linux_arm64 linux_amd64 darwin_amd64 windows_amd64 linux_arm
 
 $(TARGET):
 	go build -o $@ -ldflags "$(LDFLAGS)"


### PR DESCRIPTION
Adds a release for non-64 bit arm cpu architectures.  This supports earlier versions of Raspberry Pi if you're cheap like I am and refuse to upgrade.

I ran the build, copied the linux_arm release to an older Raspberry Pi and was able to run the tool and observe Docker socket events getting logged to my Slack organization. 

Thanks for sharing your work!  Your project will help me shoring up some uptime issues with a family project!