### PR TITLE
Allow overriding of Makefile env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /dist/
 
 /slack-docker
+
+# direnv file that sets directory-scoped environment variables; useful for testing the Makefile targets
+.envrc 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TARGET := slack-docker
 VERSION ?= latest
-GITHUB_USERNAME := int128
-GITHUB_REPONAME := slack-docker
+GITHUB_USERNAME ?= int128
+GITHUB_REPONAME ?= slack-docker
 LDFLAGS := -X main.version=$(VERSION)
 OSARCH := linux_arm64 linux_amd64 darwin_amd64 windows_amd64 linux_arm
 


### PR DESCRIPTION
Enables an environment to override the default Makefile environment
variables used to release the compiled binaries.